### PR TITLE
Feature/011 render bullet

### DIFF
--- a/MonoGameProj/MonoGameProj/Assets/AssetLoader.cs
+++ b/MonoGameProj/MonoGameProj/Assets/AssetLoader.cs
@@ -19,7 +19,7 @@ namespace MonoGameProj.Assets
         {
             if (textureMap.ContainsKey(textureName))
             {
-                return textureMap["textuireName"];
+                return textureMap[textureName];
             }
             
             // If texture is not in the Dictionary load it and add it

--- a/MonoGameProj/MonoGameProj/Assets/AssetLoader.cs
+++ b/MonoGameProj/MonoGameProj/Assets/AssetLoader.cs
@@ -1,21 +1,32 @@
 ﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGameProj.Constants;
+using System.Collections.Generic;
 
 namespace MonoGameProj.Assets
 {
     public class AssetLoader
     {
         private ContentManager content;
+        private IDictionary<string, Texture2D> textureMap;
 
         public AssetLoader(ContentManager content)
         {
             this.content = content;
+            textureMap = new Dictionary<string, Texture2D>();
         }
 
         public Texture2D RetrieveSpiteTexture(string textureName)
         {
-           return content.Load<Texture2D>(textureName);
+            if (textureMap.ContainsKey(textureName))
+            {
+                return textureMap["textuireName"];
+            }
+            
+            // If texture is not in the Dictionary load it and add it
+            Texture2D loadedTexture = content.Load<Texture2D>(textureName);
+            textureMap.Add(textureName, loadedTexture);
+
+            return loadedTexture;
         }
     }
 }

--- a/MonoGameProj/MonoGameProj/Constants/AssetNames.cs
+++ b/MonoGameProj/MonoGameProj/Constants/AssetNames.cs
@@ -13,5 +13,10 @@ namespace MonoGameProj.Constants
             public static readonly string Default_Player_Sprite = "target";
             public static readonly string Player_One_Sprite = "target";
         }
+
+        public static class BulletAssets
+        {
+            public static readonly string Default_Bullet_Sprite = "bullet";
+        }
     }
 }

--- a/MonoGameProj/MonoGameProj/Constants/EntityConstants.cs
+++ b/MonoGameProj/MonoGameProj/Constants/EntityConstants.cs
@@ -12,6 +12,7 @@ namespace MonoGameProj.Constants
         {
             public static int Small_Handgun_Bullet_Weight = 5;
             public static int Small_Handgun_Base_Speed = 5;
+            public static string Small_Handgun_Texture_Name = "bullet";
         }
 
         public static class DimensionConstants

--- a/MonoGameProj/MonoGameProj/Entities/Entity.cs
+++ b/MonoGameProj/MonoGameProj/Entities/Entity.cs
@@ -21,7 +21,7 @@ namespace MonoGameProj.Entities
             };
         }
 
-        public Texture2D Sprite { get; set; }
+        public string Sprite { get; set; }
 
         public EntityDimensions Dimensions { get; set; }
 

--- a/MonoGameProj/MonoGameProj/Entities/GameObjects/Bullets/Bullet.cs
+++ b/MonoGameProj/MonoGameProj/Entities/GameObjects/Bullets/Bullet.cs
@@ -14,7 +14,7 @@ namespace MonoGameProj.Entities.GameObjects
         public int Weight { get; set; }
         public int BaseSpeed { get; set; }
         public int Speed { get; set; }
-        public Texture2D BulletSprite { get; set; }
+        public string Sprite { get; set; }
         public Vector2 Position { get; set; }
         public EntityDimensions Dimensions { get; set; }
         public BulletType BulletType { get; set; }

--- a/MonoGameProj/MonoGameProj/Entities/GameObjects/Bullets/Bullet.cs
+++ b/MonoGameProj/MonoGameProj/Entities/GameObjects/Bullets/Bullet.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGameProj.Constants;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MonoGameProj.Entities.GameObjects
 {

--- a/MonoGameProj/MonoGameProj/Entities/GameObjects/Bullets/SmallHandgunBullet.cs
+++ b/MonoGameProj/MonoGameProj/Entities/GameObjects/Bullets/SmallHandgunBullet.cs
@@ -15,6 +15,7 @@ namespace MonoGameProj.Entities.GameObjects
                 Height = EntityConstants.BulletDimensionConstants.Handgun_Height_Value
             };
 
+            Sprite = EntityConstants.SmallHandgunConstants.Small_Handgun_Texture_Name;
             BulletType = BulletType.SMALL_HANDGUN;
         }
     }

--- a/MonoGameProj/MonoGameProj/Entities/GameObjects/Guns/Gun.cs
+++ b/MonoGameProj/MonoGameProj/Entities/GameObjects/Guns/Gun.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using MonoGameProj.Assets;
 using MonoGameProj.Constants;
 using MonoGameProj.Factories;
 using System;

--- a/MonoGameProj/MonoGameProj/Managers/GameManager.cs
+++ b/MonoGameProj/MonoGameProj/Managers/GameManager.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGameProj.Assets;
 using MonoGameProj.Entities.Collections;
 using MonoGameProj.Entities.Players;
 using MonoGameProj.Managers.PlayerMangers;
@@ -18,20 +19,26 @@ namespace MonoGameProj.Managers
         private GameSetup gameSetupManager;
         private PlayerActionManager playerActionManager;
 
+        // Assets
+        private AssetLoader assetLoader;
+
         // Rendering
         private RenderingManager renderingManager;
 
         public GameManager(ContentManager content)
         {
+            // Assets
+            assetLoader = new AssetLoader(content);
+
             // Collections
             entityList = new EntityList();
             bulletList = new BulletList();
 
             // Rendering
-            renderingManager = new RenderingManager();
+            renderingManager = new RenderingManager(assetLoader);
 
             // Game setup
-            gameSetupManager = new GameSetup(content);
+            gameSetupManager = new GameSetup();
             playerList = gameSetupManager.SetUpPlayers();
             playerActionManager = new PlayerActionManager();
         }

--- a/MonoGameProj/MonoGameProj/Managers/GameManager.cs
+++ b/MonoGameProj/MonoGameProj/Managers/GameManager.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using MonoGameProj.Entities.Collections;
 using MonoGameProj.Entities.Players;
 using MonoGameProj.Managers.PlayerMangers;
+using System;
 
 namespace MonoGameProj.Managers
 {
@@ -41,11 +42,14 @@ namespace MonoGameProj.Managers
             {
                 playerActionManager.HandlePlayerActions(player, bulletList);
             }
+
+            Console.WriteLine(bulletList.GetEntityList().Count);
         }
 
         public void Draw(SpriteBatch spriteBatch)
         {
             renderingManager.DrawPlayers(playerList.GetEntityList(), spriteBatch);
+            renderingManager.DrawBullets(bulletList.GetEntityList(), spriteBatch);
         }
     }
 }

--- a/MonoGameProj/MonoGameProj/Managers/RenderingManager.cs
+++ b/MonoGameProj/MonoGameProj/Managers/RenderingManager.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGameProj.Assets;
 using MonoGameProj.Entities;
 using MonoGameProj.Entities.GameObjects;
 using MonoGameProj.Entities.Players;
@@ -9,11 +10,18 @@ namespace MonoGameProj.Managers
 {
     public class RenderingManager
     {
+        private AssetLoader assetLoader;
+
+        public RenderingManager(AssetLoader assetLoader)
+        {
+            this.assetLoader = assetLoader;
+        }
+
         public void DrawBullets(List<Bullet> bullets, SpriteBatch spriteBatch)
         {
             foreach(Bullet bullet in bullets)
             {
-                spriteBatch.Draw(bullet.BulletSprite, bullet.Position, Color.White);
+                spriteBatch.Draw(assetLoader.RetrieveSpiteTexture(bullet.Sprite), bullet.Position, Color.White);
             }
         }
 
@@ -21,7 +29,7 @@ namespace MonoGameProj.Managers
         {
             foreach (Entity entity in entities)
             {
-                spriteBatch.Draw(entity.Sprite, entity.Position, Color.White);
+                spriteBatch.Draw(assetLoader.RetrieveSpiteTexture(entity.Sprite), entity.Position, Color.White);
             }
         }
 
@@ -29,7 +37,7 @@ namespace MonoGameProj.Managers
         {
             foreach (Player player in players)
             {
-                spriteBatch.Draw(player.Sprite, player.Position, Color.White);
+                spriteBatch.Draw(assetLoader.RetrieveSpiteTexture(player.Sprite), player.Position, Color.White);
             }
         }
     }

--- a/MonoGameProj/MonoGameProj/Setup/GameSetup.cs
+++ b/MonoGameProj/MonoGameProj/Setup/GameSetup.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGameProj.Assets;
 using MonoGameProj.Entities.Collections;
 using MonoGameProj.Entities.Players;
 using System.Collections.Generic;
@@ -8,20 +9,18 @@ namespace MonoGameProj.Managers
 {
     public class GameSetup
     {
-        private readonly PlayerSetup playerSetupManager;
+        private readonly PlayerSetup playerSetup;
         private PlayerKeyAssociation playerKeyAssociationManager;
-        private ContentManager content;
 
-        public GameSetup(ContentManager content)
+        public GameSetup()
         {
-            this.content = content;
             playerKeyAssociationManager = new PlayerKeyAssociation();
-            playerSetupManager = new PlayerSetup(content);
+            playerSetup = new PlayerSetup();
         }
 
         public PlayerList SetUpPlayers()
         {
-            var players = playerSetupManager.SetupPlayers(1);
+            var players = playerSetup.SetupPlayers(1);
             SetUpPlayerControls(players);
 
             return new PlayerList(players);

--- a/MonoGameProj/MonoGameProj/Setup/PlayerSetup.cs
+++ b/MonoGameProj/MonoGameProj/Setup/PlayerSetup.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
-using Microsoft.Xna.Framework.Graphics;
 using MonoGameProj.Assets;
 using MonoGameProj.Constants;
 using MonoGameProj.Entities.GameObjects.Guns;

--- a/MonoGameProj/MonoGameProj/Setup/PlayerSetup.cs
+++ b/MonoGameProj/MonoGameProj/Setup/PlayerSetup.cs
@@ -12,14 +12,10 @@ namespace MonoGameProj.Managers
     public class PlayerSetup
     {
         private GunFactory gunFactory;
-        private ContentManager content;
-        private AssetLoader assetLoader;
 
-        public PlayerSetup(ContentManager content)
+        public PlayerSetup()
         {
             gunFactory = new GunFactory();
-            this.content = content;
-            assetLoader = new AssetLoader(content);
         }
 
         public List<Player> SetupPlayers(int numOfPlayers)
@@ -54,12 +50,7 @@ namespace MonoGameProj.Managers
 
             textureName = AssetNames.PlayerAssets.Default_Player_Sprite;
 
-            SetPlayerTexture(player, textureName);
-        }
-
-        private void SetPlayerTexture(Player player, string textureName)
-        {
-            player.Sprite = assetLoader.RetrieveSpiteTexture(textureName);
+            player.Sprite = textureName;
         }
     }
 }


### PR DESCRIPTION
Refactored rendering to be separate from game logic. Now each game entity only needs to hold a string for it's texture (which are assigned from EntityConstants). The string is then compared to a dictionary held in AssetLoader. This assetLoader is a wrapper for the inbuilt MonoGame ContentManger. 

This allows dynamic loading of textures (as opposed to before where the player textures and bulleets were loaded initially in Game1.CS) and means only one copy of each terxture will be held in memory at any one time and reused. This asset loader is then used in the rendering manager to lookup a game objects sprite and render then at the appropriate positions. 

Much cleaner than before.